### PR TITLE
Fix/broken tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,6 @@ jobs:
         sudo apt-get install libcups2-dev wamerican
 
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
         sudo apt-get install libcups2-dev wamerican
 
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/edc_csf/form_validators.py
+++ b/edc_csf/form_validators.py
@@ -110,6 +110,7 @@ class LpCsfFormValidatorMixin(
     CrfRequisitionFormValidatorMixin,
     LpFormValidatorMixin,
     QuantitativeCsfFormValidatorMixin,
+    CsfCultureFormValidatorMixin,
 ):
 
     requisition_fields = [
@@ -122,6 +123,8 @@ class LpCsfFormValidatorMixin(
         self.validate_lp()
 
         self.validate_quantitative_culture("qc_requisition")
+
+        self.validate_csf_culture()
 
 
 class LpCsfFormValidator(LpCsfFormValidatorMixin, FormValidator):

--- a/edc_csf/tests/tests/test_form.py
+++ b/edc_csf/tests/tests/test_form.py
@@ -225,10 +225,10 @@ class TestLpFormValidator(TestCase):
                     f"ValidationError unexpectedly raised. " f"Got {form_validator._errors}"
                 )
 
-    def test_csf_crag_no_csf_crag_lfa_not_required(self):
+    def test_csf_crag_not_done_csf_crag_lfa_not_required(self):
         cleaned_data = {
             "subject_visit": self.subject_visit,
-            "csf_positive": NOT_DONE,
+            "csf_crag": NOT_DONE,
             "csf_crag_lfa": YES,
         }
         form_validator = LpCsfFormValidator(cleaned_data=cleaned_data, instance=LpCsf())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ py_version = "39"
 skip = [".tox", ".eggs", "migrations"]
 
 [tool.coverage.run]
-parallel = true
+parallel = false
 branch = true
 source = ["edc_csf"]
 


### PR DESCRIPTION
7 tests were failing.

Adding to `CsfCultureFormValidatorMixin` and `self.validate_csf_culture()` to `LpCsfFormValidatorMixin` gets them passing again, though am not sure whether this is the right approach (or whether the tests were just out of date)

It also seems `validate_csf_culture()` is overridden in `effect-edc` anyway.  
